### PR TITLE
Update firestore rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -2,8 +2,8 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
     match /{document=**} {
-      allow read, write: if
-          request.time < timestamp.date(2020, 10, 24);
+      allow read: if true;
+      allow write: if false;
     }
   }
 }


### PR DESCRIPTION
Temporarily allow all reads to the data and deny all writes to the data. This means that any writes need to be done from Cloud functions or in Firestore itself. After authentication is set up, this will be changed to authenticated users can write.