### PR TITLE
Fix broken link to EPA Air Now formula

### DIFF
--- a/functions/src/aqi-calculation/nowcast-concentration.ts
+++ b/functions/src/aqi-calculation/nowcast-concentration.ts
@@ -45,7 +45,7 @@ export default class NowCastConcentration {
     let currentHourWeight = 1;
     // Most recent hour has index 0, older readings have larger indices
     // Formula from the EPA at
-    // https://www.airnow.gov/faqs/how-nowcast-algorithm-used-report/
+    // https://usepa.servicenowservices.com/airnow?id=kb_article&sys_id=fed0037b1b62545040a1a7dbe54bcbd4
     for (let i = 0; i < cleanedAverages.readings.length; i++) {
       if (!Number.isNaN(cleanedAverages.readings[i])) {
         weightedAverageSum += currentHourWeight * cleanedAverages.readings[i];


### PR DESCRIPTION
It appears they are now using a ServiceNow instance to host their knowledge base. It is possible they will change this link again. 

Fixes #436