### PR TITLE
Bug Fix: Correct PM 2.5 buffer length

### DIFF
--- a/functions/src/aqi-calculation/buffer.ts
+++ b/functions/src/aqi-calculation/buffer.ts
@@ -88,9 +88,9 @@ function populateDefaultBuffer(aqiBuffer: boolean, docId: string): void {
       }
     });
   } else {
-    // 3600 = (30 calls/ hour * 12 hours) is the amount of data needed for
+    // 360 = (30 calls/ hour * 12 hours) is the amount of data needed for
     // the AQI NowCast calculation
-    const bufferSize = 3600;
+    const bufferSize = 360;
     const pm25Buffer: Array<Pm25BufferElement> = Array(bufferSize).fill(
       defaultPm25BufferElement
     );

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -112,17 +112,22 @@ exports.thingspeakToFirestore = functions
         if (status === bufferStatus.Exists) {
           // If the buffer exists, update normally
           const pm25Buffer = sensorDocData.pm25Buffer;
-          pm25Buffer[sensorDocData.pm25BufferIndex] = firestoreSafeReading;
-
-          // Update the sensor doc buffer and metadata
-          await sensorDocRef.update({
-            pm25BufferIndex:
-              (sensorDocData.pm25BufferIndex + 1) % pm25Buffer.length, // eslint-disable-line no-magic-numbers
-            pm25Buffer: pm25Buffer,
-            lastSensorReadingTime: readingTimestamp,
-            latitude: reading.latitude,
-            longitude: reading.longitude,
-          });
+          // This if/else statement is temporary to correct the length of the buffers
+          // TODO: remove this code after the bug has been fixed
+          if( pm25Buffer.length != 360){
+            populateDefaultBuffer(false,sensorDoc.id)
+          }else{
+            pm25Buffer[sensorDocData.pm25BufferIndex] = firestoreSafeReading;
+            // Update the sensor doc buffer and metadata
+            await sensorDocRef.update({
+              pm25BufferIndex:
+                (sensorDocData.pm25BufferIndex + 1) % pm25Buffer.length, // eslint-disable-line no-magic-numbers
+              pm25Buffer: pm25Buffer,
+              lastSensorReadingTime: readingTimestamp,
+              latitude: reading.latitude,
+              longitude: reading.longitude,
+            });
+          }
         } else if (status === bufferStatus.DoesNotExist) {
           // If the buffer does not exist, populate it with default values so
           // it can be updated in the future

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -114,9 +114,18 @@ exports.thingspeakToFirestore = functions
           const pm25Buffer = sensorDocData.pm25Buffer;
           // This if/else statement is temporary to correct the length of the buffers
           // TODO: remove this code after the bug has been fixed
-          if( pm25Buffer.length != 360){
-            populateDefaultBuffer(false,sensorDoc.id)
-          }else{
+          // eslint-disable-next-line no-magic-numbers
+          if (pm25Buffer.length !== 360) {
+            // Buffer is in progress
+            await sensorDocRef.update({
+              pm25BufferStatus: bufferStatus.InProgress,
+              lastSensorReadingTime: readingTimestamp,
+              latitude: reading.latitude,
+              longitude: reading.longitude,
+            });
+            // Repopulate with defaults
+            populateDefaultBuffer(false, sensorDoc.id);
+          } else {
             pm25Buffer[sensorDocData.pm25BufferIndex] = firestoreSafeReading;
             // Update the sensor doc buffer and metadata
             await sensorDocRef.update({


### PR DESCRIPTION
Mistakenly thought that the PM 2.5 buffer needed to be of length 3600, but really it only needs to be of length 360. This PR fixes that bug and adds an if statement that will correct the existing buffers in the database that we will delete after the fix has been made.