### PR TITLE
added key to paths for arcs in dial

### DIFF
--- a/src/components/AqiGauge/GaugeSvg.tsx
+++ b/src/components/AqiGauge/GaugeSvg.tsx
@@ -110,6 +110,7 @@ const GaugeSvg: ({currentAqi}: DialProps) => JSX.Element = ({
         stroke="black"
         strokeWidth={0.002}
         fillOpacity={opacity}
+        key={i}
       />
     );
   }


### PR DESCRIPTION
Noticed this error started coming up where elements needed to have a unique key for the colored arcs in GaugeSVG.tsx (used to generate the svg image for the dial). This fixes that. 