### PR TITLE
Deletion Phase 0c: Follow correct module boundry typing

### DIFF
--- a/functions/.eslintrc.json
+++ b/functions/.eslintrc.json
@@ -99,7 +99,8 @@
           "Subcollection",
           "breakpoint",
           "Breakpoint",
-          "uid"
+          "uid",
+          "purpleair"
         ]
       }
     ]

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -56,7 +56,7 @@ async function isAdmin(context: CallableContext): Promise<boolean> {
 }
 
 exports.testCallable = functions.https.onCall(
-  async (data: any, // eslint-disable-line 
+  async (data: object | null | undefined, // eslint-disable-line 
     context: CallableContext
   ) => {
   console.log("In the testCallable") // eslint-disable-line

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -5,7 +5,7 @@ import {
 import {firestore, functions} from './admin';
 import {calculateAqi} from './aqi-calculation/calculate-aqi';
 import {purpleAirToFirestore} from './aqi-calculation/purple-air-response';
-import {EventContext} from 'firebase-functions';
+import {CallableContext} from 'firebase-functions/lib/providers/https';
 
 exports.purpleAirToFirestore = functions.pubsub
   .schedule('every 2 minutes')
@@ -31,7 +31,8 @@ exports.generateAverageReadingsCsv = functions.pubsub
   .onPublish(generateAverageReadingsCsv);
 
 // Returns true if the current user is authenticated and is an admin user
-async function isAdmin(context: EventContext): Promise<boolean> {
+async function isAdmin(context: CallableContext): Promise<boolean> {
+  /* eslint-disable */
   console.log("entered isAdmin")
   console.log("context object")
   console.log(context)
@@ -50,18 +51,25 @@ async function isAdmin(context: EventContext): Promise<boolean> {
     return userDocument.data()?.isAdmin ?? false;
   }
   console.log("Never entered if branch of isAdmin")
+  /* eslint-enable */
   return false;
 }
 
-exports.testCallable = functions.https.onCall(async (context: EventContext) => {
-  console.log("In the testCallable")
-  if (!(await isAdmin(context))) {
+exports.testCallable = functions.https.onCall(
+  async (data: any, // eslint-disable-line 
+    context: CallableContext
+  ) => {
+  console.log("In the testCallable") // eslint-disable-line
+    if (!(await isAdmin(context))) {
     console.log('Not an admin'); // eslint-disable-line
-    throw new functions.https.HttpsError(
-      'permission-denied',
-      'Must be an administrative user to initiate delete.'
-    );
-  } else {
+      throw new functions.https.HttpsError(
+        'permission-denied',
+        'Must be an administrative user to initiate delete.'
+      );
+    } else {
     console.log('An admin'); // eslint-disable-line
+    }
+
+    return Promise.resolve();
   }
-});
+);

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -56,9 +56,7 @@ async function isAdmin(context: CallableContext): Promise<boolean> {
 }
 
 exports.testCallable = functions.https.onCall(
-  async (data: object | null | undefined, // eslint-disable-line 
-    context: CallableContext
-  ) => {
+  async (data: undefined, context: CallableContext) => {
   console.log("In the testCallable") // eslint-disable-line
     if (!(await isAdmin(context))) {
     console.log('Not an admin'); // eslint-disable-line


### PR DESCRIPTION
It appears that Google does require the `data: any` parameter in addition to the `context: CallableContext` parameter. We were experiencing no authentication because it was getting passed to the wrong object. Because `any` is the correct type, the linter must be disabled on the line. In the actual code later we will make sure only that no-explicit-any is disabled, but given the amount of disabling on the page for this test, we will let it slide for now. 