### PR TITLE
set cache control max time to 1 hour (3600 seconds)

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -21,7 +21,14 @@
         "source": "**",
         "destination": "/index.html"
       }
-    ]
+    ],
+    "headers": [{
+      "source": "**",
+      "headers":[{
+        "key" : "Cache-Control",
+        "value": "max-age=3600"
+      }]
+    }]
   },
   "emulators": {
     "functions": {


### PR DESCRIPTION
I won't really know if this works until we deploy it, but it seems legit.

Found this information here:
[docs on caching](https://firebase.google.com/docs/hosting/manage-cache)
[docs on hosting](https://firebase.google.com/docs/hosting/full-config)
[stack overflow](https://stackoverflow.com/questions/38114755/cache-control-header-in-firebase-json-not-working)

Not closing issue  #539 until I know it's fixed.