### PR TITLE
Fix activate/deactivate bug

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -124,6 +124,7 @@
           "csv",
           "num",
           "axios",
+          "Axios",
           "camelcase",
           "monday",
           "tuesday",

--- a/public/locales/en/administration.json
+++ b/public/locales/en/administration.json
@@ -206,7 +206,7 @@
         "confirmDownload": "I have downloaded any data I need.",
         "acknowledgeDelete": "I acknowledge that this action will delete any historical data for this sensor.",
         "cannotBeUndone": "I acknowledge that this action cannot be undone",
-        "note": "Deleting a sensor will remove it from the map and delete all of its data. You will need to re-add the sensor to show this sensor on the map again and to collect this sensor's data. If you only want to temporarily stop showing this sensor or collecting data for this sensor, deactivate the sensor instead.",
+        "note": "Deleting a sensor will remove it from the map and delete all of its data. You will need to re-add the sensor to show this sensor on the map again and to collect this sensor's data. If you only want to temporarily stop showing this sensor or collecting data for this sensor, deactivate the sensor instead. You can only delete a sensor that has been deactivated, so make sure you deactivate a sensor you intend to delete first.",
         "confirmPurpleAirId": "Type the PurpleAir ID of the sensor to confirm deletion",
         "whichSensorToDelete": "Which sensor would you like to delete?"
     }

--- a/public/locales/es/administration.json
+++ b/public/locales/es/administration.json
@@ -206,7 +206,7 @@
         "confirmDownload": "He descargado los datos que necesito.",
         "acknowledgeDelete": "Reconozco que esta acción borrará los datos históricos de este sensor.",
         "cannotBeUndone": "Reconozco que esta acción no se puede deshacer.",
-        "note": "Borrar un sensor lo borrará del mapa y borrará todos sus datos. Deberás volver a agregar el sensor para mostrar este sensor en el mapa nuevamente y recopilar los datos de este sensor. Si solo deseas dejar de mostrar este sensor temporalmente o de recopilar datos para este sensor, desactiva el sensor en su lugar. Solo puede borrar un sensor que se haya desactivado, así que asegúrase de desactivar primero un sensor que desees borrar.",
+        "note": "Borrar un sensor lo borrará del mapa y borrará todos sus datos. Deberás volver a agregar el sensor para mostrar este sensor en el mapa nuevamente y recopilar los datos de este sensor. Si solo deseas dejar de mostrar este sensor temporalmente o de recopilar datos para este sensor, desactiva el sensor en su lugar. Solo puedes borrar un sensor que se haya desactivado, así que asegúrase de desactivar primero un sensor que desees borrar.",
         "confirmPurpleAirId": "Escriba el ID de PurpleAir del sensor para confirmar la supresión",
         "whichSensorToDelete": "¿Cuál sensor te gustaría borrar?",
         "error": "No se puede borrar el sensor. Por favor trata otra vez más tarde."

--- a/public/locales/es/administration.json
+++ b/public/locales/es/administration.json
@@ -206,7 +206,7 @@
         "confirmDownload": "He descargado los datos que necesito.",
         "acknowledgeDelete": "Reconozco que esta acción borrará los datos históricos de este sensor.",
         "cannotBeUndone": "Reconozco que esta acción no se puede deshacer.",
-        "note": "Borrar un sensor lo borrará del mapa y borrará todos sus datos. Deberás volver a agregar el sensor para mostrar este sensor en el mapa nuevamente y recopilar los datos de este sensor. Si solo deseas dejar de mostrar este sensor temporalmente o de recopilar datos para este sensor, desactiva el sensor en su lugar.",
+        "note": "Borrar un sensor lo borrará del mapa y borrará todos sus datos. Deberás volver a agregar el sensor para mostrar este sensor en el mapa nuevamente y recopilar los datos de este sensor. Si solo deseas dejar de mostrar este sensor temporalmente o de recopilar datos para este sensor, desactiva el sensor en su lugar. Solo puede borrar un sensor que se haya desactivado, así que asegúrase de desactivar primero un sensor que desees borrar.",
         "confirmPurpleAirId": "Escriba el ID de PurpleAir del sensor para confirmar la supresión",
         "whichSensorToDelete": "¿Cuál sensor te gustaría borrar?",
         "error": "No se puede borrar el sensor. Por favor trata otra vez más tarde."

--- a/src/components/Admin/ManageSensors/AddSensorModal.tsx
+++ b/src/components/Admin/ManageSensors/AddSensorModal.tsx
@@ -176,6 +176,9 @@ function AddSensorModal(): JSX.Element {
           },
         });
 
+        // Value for AQI and PM2.5 buffer, from bufferStatus in backend
+        const bufferDoesNotExist = 2;
+
         // Create a sensor doc for the added sensor
         await firestore.collection('sensors').add({
           name: sensorName,
@@ -186,6 +189,8 @@ function AddSensorModal(): JSX.Element {
           isValid: false,
           lastValidAqiTime: null,
           lastSensorReadingTime: null,
+          aqiBufferStatus: bufferDoesNotExist,
+          pm25BufferStatus: bufferDoesNotExist,
         });
         setSensorAdded(true);
       } catch {

--- a/src/components/Admin/ManageSensors/DeleteSensorModal.tsx
+++ b/src/components/Admin/ManageSensors/DeleteSensorModal.tsx
@@ -175,7 +175,7 @@ const DeleteSensorModal: ({sensors}: DeleteSensorModalProps) => JSX.Element = ({
    * ID to the timestamp for which to delete readings before
    * @returns Promise that when resolved contains the todo deletion document
    */
-  function getDeletionMap(): Promise<
+  function getDeletionToDoDoc(): Promise<
     firebase.firestore.DocumentSnapshot<firebase.firestore.DocumentData>
   > {
     return firestore.collection('deletion').doc('todo').get();
@@ -201,7 +201,7 @@ const DeleteSensorModal: ({sensors}: DeleteSensorModalProps) => JSX.Element = ({
       // Finally, delete the sensor doc, and close the modal upon success.
       getPurpleAirMemberId()
         .then(memberId => deleteFromPurpleAirGroup(memberId))
-        .then(getDeletionMap)
+        .then(getDeletionToDoDoc)
         .then(deleteDoc => updateDeletionMap(deleteDoc))
         .then(deleteSensorDoc)
         .then(handleClose)

--- a/src/components/Admin/ManageSensors/ManageSensors.tsx
+++ b/src/components/Admin/ManageSensors/ManageSensors.tsx
@@ -233,7 +233,9 @@ const ManageSensors: () => JSX.Element = () => {
               <AddSensorModal />
               <DownloadCSVModal sensors={sensors} />
               <DeleteOldDataModal />
-              <DeleteSensorModal sensors={sensors} />
+              <DeleteSensorModal
+                sensors={sensors.filter(sensor => !sensor.isActive)}
+              />
             </HStack>
           </Center>
           <Box maxWidth="100%" overflowX="auto">

--- a/src/components/Admin/ManageSensors/ManageSensors.tsx
+++ b/src/components/Admin/ManageSensors/ManageSensors.tsx
@@ -98,15 +98,18 @@ const ManageSensors: () => JSX.Element = () => {
 
     if (isAdmin) {
       // Toggle the isActive and remove the buffers
+
+      // Value from bufferStatus enum in backend
+      const bufferDoesNotExist = 2;
       firestore
         .collection('sensors')
         .doc(currentSensor.docId)
         .update({
           isActive: !currentSensor.isActive,
-          aqiBufferStatus: firebase.firestore.FieldValue.delete(),
+          aqiBufferStatus: bufferDoesNotExist,
           aqiBuffer: firebase.firestore.FieldValue.delete(),
           aqiBufferIndex: firebase.firestore.FieldValue.delete(),
-          pm25BufferStatus: firebase.firestore.FieldValue.delete(),
+          pm25BufferStatus: bufferDoesNotExist,
           pm25Buffer: firebase.firestore.FieldValue.delete(),
           pm25BufferIndex: firebase.firestore.FieldValue.delete(),
         })

--- a/src/components/Admin/ManageSensors/ManageSensors.tsx
+++ b/src/components/Admin/ManageSensors/ManageSensors.tsx
@@ -79,7 +79,8 @@ const ManageSensors: () => JSX.Element = () => {
   }, [isAuthenticated, isAdmin]);
 
   /**
-   *
+   * Toggles `isActive` in a sensor's doc. This also resets the AQI buffer
+   * and PM2.5 buffer when activating or deactivating.
    * @param event - click button event
    * @param currentSensor - sensor for which to toggle isActive status
    */
@@ -89,12 +90,21 @@ const ManageSensors: () => JSX.Element = () => {
   ) {
     event.preventDefault();
 
+    // Value from backend, where 2 denotes that the buffer doesn't exist
+    const bufferDoesNotExist = 2;
+
     if (isAdmin) {
       firestore
         .collection('sensors')
         .doc(currentSensor.readingDocId)
         .update({
           isActive: !currentSensor.isActive,
+          aqiBufferStatus: bufferDoesNotExist,
+          aqiBuffer: firebase.firestore.FieldValue.delete(),
+          aqiBufferIndex: firebase.firestore.FieldValue.delete(),
+          pm25BufferStatus: bufferDoesNotExist,
+          pm25Buffer: firebase.firestore.FieldValue.delete(),
+          pm25BufferIndex: firebase.firestore.FieldValue.delete(),
         })
         .catch(() => {
           setError(

--- a/src/components/Admin/ManageSensors/ManageSensors.tsx
+++ b/src/components/Admin/ManageSensors/ManageSensors.tsx
@@ -97,10 +97,10 @@ const ManageSensors: () => JSX.Element = () => {
     event.preventDefault();
 
     if (isAdmin) {
-      // Toggle the isActive and remove the buffers
-
       // Value from bufferStatus enum in backend
       const bufferDoesNotExist = 2;
+
+      // Toggle the isActive and remove the buffers
       firestore
         .collection('sensors')
         .doc(currentSensor.docId)

--- a/src/components/Admin/ManageSensors/Util.tsx
+++ b/src/components/Admin/ManageSensors/Util.tsx
@@ -178,5 +178,19 @@ const MoreInfoHeading: ({
   );
 };
 
-export type {Sensor};
+/**
+ * Structure of a PurpleAir group member returned from the PurpleAir API GET
+ * request to get all members of a PurpleAir group.
+ * - `id` - the member ID for the sensor in the queried group
+ * - `sensor_index` - the PurpleAir ID for the sensor in the queried group
+ * - `created` - the number of milliseconds since EPOCH when the sensor was
+ *   added to the queried group
+ */
+interface PurpleAirGroupMember {
+  id: number;
+  sensor_index: number; // eslint-disable-line camelcase
+  created: number;
+}
+
+export type {Sensor, PurpleAirGroupMember};
 export {LabelValue, SensorInput, MoreInfoHeading};


### PR DESCRIPTION
This resets the buffers when a sensor is activated or deactivated.

This also fixes a bug with sensor deletion--when a sensor is deleted, it is now removed from the PurpleAir group 490, which we use to get data.

Additionally, this only allows deactivated sensors to be deleted. This helps address a possible bug where the getPurpleAir data function is running while the sensor's doc is being deleted--now this cannot happen.

Note that when a sensor is activated or deactivated, we do not modify the PurpleAir group 490 as a matter of simplicity. PurpleAir will continue to give us data in our request for deactivated sensors, but the backend code will ignore the reading.