### PR TITLE
Fix purpleAirToFirestore Update() error

### DIFF
--- a/functions/src/aqi-calculation/buffer.ts
+++ b/functions/src/aqi-calculation/buffer.ts
@@ -1,7 +1,7 @@
-import {firestore} from '../admin';
+import {firestore, Timestamp} from '../admin';
 
 /**
- * Interface for a single element in the pm25Buffer.
+ * Interface for a single element in the `pm25Buffer`.
  */
 interface Pm25BufferElement {
   timestamp: FirebaseFirestore.Timestamp | null;
@@ -40,11 +40,11 @@ function getDefaultPm25BufferElement(): Pm25BufferElement {
 
 /**
  * Interface for a single element in the AQI buffer
- * timestamp - when this AQI was calculated and added to the buffer
- * aqi - the current aqi value
+ * - `timestamp` - when this AQI was calculated and added to the buffer, or `null` if no valid AQI
+ * - `aqi` - the current aqi value, or `NaN` if no valid AQI
  */
 interface AqiBufferElement {
-  timestamp: FirebaseFirestore.FieldValue | null;
+  timestamp: FirebaseFirestore.Timestamp | null;
   aqi: number;
 }
 

--- a/functions/src/aqi-calculation/buffer.ts
+++ b/functions/src/aqi-calculation/buffer.ts
@@ -1,4 +1,4 @@
-import {firestore, Timestamp} from '../admin';
+import {FieldValue, firestore} from '../admin';
 
 /**
  * Interface for a single element in the `pm25Buffer`.
@@ -110,6 +110,7 @@ function populateDefaultBuffer(aqiBuffer: boolean, docId: string): void {
           aqiBufferIndex: bufferIndex,
           aqiBuffer: aqiBuffer,
           aqiBufferStatus: bufferStatus.Exists,
+          lastUpdated: FieldValue.serverTimestamp(),
         });
       }
     });
@@ -128,6 +129,7 @@ function populateDefaultBuffer(aqiBuffer: boolean, docId: string): void {
           pm25BufferIndex: bufferIndex,
           pm25Buffer: pm25Buffer,
           pm25BufferStatus: bufferStatus.Exists,
+          lastUpdated: FieldValue.serverTimestamp(),
         });
       }
     });

--- a/functions/src/aqi-calculation/calculate-aqi.ts
+++ b/functions/src/aqi-calculation/calculate-aqi.ts
@@ -223,6 +223,7 @@ async function calculateAqi(): Promise<void> {
 
     // Update the AQI circular buffer for this element
     const sensorDocUpdate = Object.create(null);
+    sensorDocUpdate.lastUpdated = FieldValue.serverTimestamp();
     sensorDocUpdate.lastValidAqiTime = currentSensorData.lastValidAqiTime;
     sensorDocUpdate.isValid = currentSensorData.isValid;
 

--- a/functions/src/aqi-calculation/util.ts
+++ b/functions/src/aqi-calculation/util.ts
@@ -165,19 +165,8 @@ async function getLastSensorReadingTime(
   return lastSensorReadingTime;
 }
 
-/**
- * Converts the PurpleAir ID to a number, if necessary.
- * @param id - PurpleAir ID stored as a string or number
- * @returns the PurpleAir ID as a number
- */
-function getPurpleAirId(id: string | number): number {
-  if (typeof id === 'string') return +id;
-  return id;
-}
-
 export {
   readingsSubcollection,
   getReading,
   getLastSensorReadingTime,
-  getPurpleAirId,
 };

--- a/functions/src/aqi-calculation/util.ts
+++ b/functions/src/aqi-calculation/util.ts
@@ -165,8 +165,4 @@ async function getLastSensorReadingTime(
   return lastSensorReadingTime;
 }
 
-export {
-  readingsSubcollection,
-  getReading,
-  getLastSensorReadingTime,
-};
+export {readingsSubcollection, getReading, getLastSensorReadingTime};

--- a/src/components/Admin/ManageSensors/AddSensorModal.tsx
+++ b/src/components/Admin/ManageSensors/AddSensorModal.tsx
@@ -23,7 +23,7 @@ import {
 import {CheckCircleIcon, WarningIcon} from '@chakra-ui/icons';
 import {useTranslation} from 'react-i18next';
 import {SubmitButton} from '../ComponentUtil';
-import {firestore} from '../../../firebase';
+import firebase, {firestore} from '../../../firebase';
 import {useAuth} from '../../../contexts/AuthContext';
 import axios from 'axios';
 import {LabelValue} from './Util';
@@ -186,6 +186,7 @@ function AddSensorModal(): JSX.Element {
           isValid: false,
           lastValidAqiTime: null,
           lastSensorReadingTime: null,
+          lastUpdated: firebase.firestore.FieldValue.serverTimestamp(),
         });
         setSensorAdded(true);
       } catch {

--- a/src/components/Admin/ManageSensors/ManageSensors.tsx
+++ b/src/components/Admin/ManageSensors/ManageSensors.tsx
@@ -96,6 +96,7 @@ const ManageSensors: () => JSX.Element = () => {
         .doc(currentSensor.docId)
         .update({
           isActive: !currentSensor.isActive,
+          lastUpdated: firebase.firestore.FieldValue.serverTimestamp(),
         })
         .catch(() => {
           setError(


### PR DESCRIPTION
This PR adds a `lastUpdated` field for every update to a sensor's doc. This is necessary because the purpleAirToFirestore function was throwing errors if `update` was called but no fields were actually updated. Now, every time update is called, `lastUpdated` is set to the server timestamp.

This PR also:

- Fixes a bug in the type of the aqiBufferElement
- Fixes some documentation for the aqiBufferElement
- Adds TODOs for where a reason that a sensor is down can be determined
- Removes previous helper function to ensure that a `purpleAirId` is a number since all sensor docs have now been converted to using numbers, and all newly added sensors will also use a number

Closes #576 