### PR TITLE
Invalid sensors: changes for Dial Box & About page

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -63,6 +63,7 @@
         "skipWordIfMatch": [
           "sunday",
           "85vh",
+          "las",
           "dx",
           "dy",
           "aqi",

--- a/public/locales/en/about.json
+++ b/public/locales/en/about.json
@@ -25,7 +25,7 @@
     },
     "sensorsDown": {
         "heading": "Sensor Not Reporting AQI?",
-        "part1": "There are many steps involved in calculating the AQI using the information reported by the PurpleAir sensors that we host in South Gate. The EPA outlines the steps of this algorithm, and we follow their guidelines to ensure our sensors report accurately.",
+        "part1": "There are many steps involved in calculating the AQI using the information reported by the PurpleAir sensors that we host in South Gate. The EPA outlines the steps of this algorithm, and we follow their guidelines to ensure our sensors accurately report the AQI.",
         "part2": "PurpleAir sensors are great for our work because they are affordable and relatively accurate given their cost. That being said, they are not as reliable as some more expensive sensors, which means that sometimes the values they record aren’t sufficient for calculating the AQI. This could be very temporary (a matter of minutes or hours) or might last longer. If a sensor has been down for a long time, it probably means that either the sensor is no longer connected to the internet or that it has encountered a more serious hardware issue.",
         "part3": "If a sensor in your area has been down for a long time, feel free to contact us and we’ll communicate with the sensor host to see if we can resolve the issue."
     },

--- a/public/locales/en/about.json
+++ b/public/locales/en/about.json
@@ -25,8 +25,8 @@
     },
     "sensorsDown": {
         "heading": "Sensor Not Reporting AQI?",
-        "part1": "There are many steps involved in calculating the AQI using the information reported by the PurpleAir sensors that we host in South Gate. The steps of this algorithm have been outlined by the EPA, and we follow the EPA’s guidelines to ensure our sensors are accurate.",
-        "part2": "PurpleAir sensors are great for our work because they are affordable and relatively accurate given their cost. That being said, they are not as reliable as some more expensive sensors, which means that sometimes the values they record aren’t sufficient for calculating AQI. This could be very temporary (a matter of minutes or hours), or might last longer. If a sensor has been down for a long time, it probably means that either the sensor is no longer connected to the internet or that it has encountered a more serious hardware issue.",
+        "part1": "There are many steps involved in calculating the AQI using the information reported by the PurpleAir sensors that we host in South Gate. The EPA outlines the steps of this algorithm, and we follow their guidelines to ensure our sensors report accurately.",
+        "part2": "PurpleAir sensors are great for our work because they are affordable and relatively accurate given their cost. That being said, they are not as reliable as some more expensive sensors, which means that sometimes the values they record aren’t sufficient for calculating the AQI. This could be very temporary (a matter of minutes or hours) or might last longer. If a sensor has been down for a long time, it probably means that either the sensor is no longer connected to the internet or that it has encountered a more serious hardware issue.",
         "part3": "If a sensor in your area has been down for a long time, feel free to contact us and we’ll communicate with the sensor host to see if we can resolve the issue."
     },
     "acknowledge": {

--- a/public/locales/en/dial.json
+++ b/public/locales/en/dial.json
@@ -9,8 +9,10 @@
     "hazardous": "Hazardous (301+)",
     "invalid": {
         "lastTime": "This sensor is not up to date. The last time it reported an accurate AQI was ",
-        "at": " at ",
+        "atPlural": " at ",
+        "atSingular": " at ",
         "learnMore": ". To learn more about why a sensor might not be reporting, check out our ",
-        "aboutPage": "About Page."
+        "aboutPage": "About Page.",
+        "neverReported": "This sensor has never reported an accurate AQI"
     }
 }

--- a/public/locales/es/about.json
+++ b/public/locales/es/about.json
@@ -25,9 +25,9 @@
     },
     "sensorsDown": {
         "heading": "¿El sensor no muestra el AQI?",
-        "part1": "Hay muchos pasos involucrados en el cálculo del AQI usando la información reportada por los sensores PurpleAir que hospedamos en South Gate. La EPA ha descrito los pasos de este algoritmo y seguimos las pautas de la EPA para garantizar que nuestros sensores sean precisos.",
-        "part2": "Los sensores PurpleAir son excelentes para nosotros porque son asequibles y relativamente precisos dado su costo. Dicho esto, no son tan confiables como algunos sensores más costosos, lo que significa que a veces los valores que registran no son suficientes para calcular el AQI. Esto podría ser muy temporal (en cuestión de minutos u horas) o podría durar más. Si un sensor ha estado inactivo durante mucho tiempo, probablemente significa que el sensor ya no está conectado a Internet o que se ha encontrado un problema de hardware más grave.",
-        "part3": "Si un sensor en su área ha estado inactivo durante mucho tiempo, no dude en contactarnos y nos comunicaremos con el anfitrión del sensor para ver si podemos resolver el problema."
+        "part1": "Hay que dar muchos pasos para calcular el AQI usando la información reportada por los sensores de PurpleAir que usamos en South Gate. La EPA tiene un esquema de este algoritmo y nosotros seguimos sus pautas para garantizar que nuestros sensores sean precisos.",
+        "part2": "Los sensores PurpleAir nos caen bien porque son económicos y relativamente precisos considerando su precio. Dicho esto, no son tan confiables como algunos sensores más caros, lo que significa que a veces los valores que producen los sensores son insuficientes para calcular el AQI. Esto podría ser muy temporal (una cuestión de minutos u horas) o podría durar más tiempo. Si un sensor ha estado inactivo durante mucho tiempo, probablemente significa que el sensor ya no está conectado al Internet o que tiene un problema de hardware más grave.",
+        "part3": "Si un sensor en tu área ha estado inactivo durante mucho tiempo, por favor contáctanos y nos comunicaremos con el anfitrión del sensor para tratar de resolver el problema."
     },
     "acknowledge": {
         "heading": "Agradecimientos",

--- a/public/locales/es/dial.json
+++ b/public/locales/es/dial.json
@@ -8,9 +8,11 @@
     "very": "Muy insalubre (201-300)",
     "hazardous": "Peligroso (301+)",
     "invalid": {
-        "lastTime": "Este sensor no está actualizado. La última vez que informó un AQI preciso fue ",
-        "at": " a las ",
-        "learnMore": ". Para obtener más información sobre por qué un sensor podría no estar informando, consulte nuestra ",
-        "aboutPage": "Sobre Nosotros página."
+        "lastTime": "Este sensor no está actualizado. La última vez que el sensor reportó un AQI correcto fue el ",
+        "atPlural": " a las ",
+        "atSingular": " a la ",
+        "learnMore": ". Para aprender más sobre las razones por la cual un sensor no está reportando información actualizada, consulta esta ",
+        "aboutPage": "página Sobre Nosotros.",
+        "neverReported": "Este sensor nunca ha reportado un AQI correcto"
     }
 }


### PR DESCRIPTION
This PR does a couple things:
- Fixes translations for the home and about pages for the "invalid sensor/sensor down" stuff
- Small corrections on the English versions as well
- Uses "a las" when it's not 1 o'clock, uses "a la" when it is
- If a sensor has never given a valid reading, use different text in the dial box to reflect that.
