### PR TITLE
Bug fix: labels on AQI graph

### DIFF
--- a/src/components/AqiGraph/AqiGraph.tsx
+++ b/src/components/AqiGraph/AqiGraph.tsx
@@ -162,24 +162,25 @@ const AqiGraph: ({sensorDocId}: GraphProps) => JSX.Element = ({
 
   const formatLabels = (hoursAgo: number): string => {
     const weekdays = [
+      t('sunday'),
       t('monday'),
       t('tuesday'),
       t('wednesday'),
       t('thursday'),
       t('friday'),
       t('saturday'),
-      t('sunday'),
     ];
-    const sunday = 6;
+    const saturday = 6;
     // Get the local time from the user's browser
     const date = new Date();
-    let day = date.getDay() - 1; // Subtract 1 to put in [0,6] range
+    let day = date.getDay();
     let hour = date.getHours() - hoursAgo;
     const minutes = date.getMinutes();
     // Adjust values if the label is from the previous day
     if (hour < 0) {
       if (day === 0) {
-        day = sunday;
+        // If it's Sunday, the previous day is Saturday
+        day = saturday;
       } else {
         day -= 1;
       }


### PR DESCRIPTION
Not sure what happened here, seems like `.getDay()` returns 0 for Sunday, 6 for Saturday. Our code had implemented 0 for Monday, 6 for Sunday, which means all the labels started showing up as "undefined" (you can see it on the live site today).

This PR changes the code to reflect Sunday being 0, not 6.

Commentary: I feel like we would have noticed if this was always happening because then the graph would have always been off by a day. Not sure if/why it changed.