### PR TITLE
Add AccountDeleted Page

### DIFF
--- a/public/locales/en/administration.json
+++ b/public/locales/en/administration.json
@@ -51,7 +51,6 @@
         "email": "Sign up with email"
     },
     "signOut": "Sign Out",
-    "signOutError": "Error occurred with sign out. Please try again",
     "pageHeader": {
         "signIn": "Sign In",
         "signUp": "Sign Up"
@@ -112,5 +111,9 @@
         },
         "changeAdminError": "Unable to change admin status for ",
         "confirmChange": "Confirm Admin Status Change"
+    }, 
+    "deletedAccount": {
+        "deleteNow": "Finish Account Deletion Now",
+        "explanation": "Your account has been deleted by an administrator of the website, and the account will be deleted within the next 24 hours. If you believe this is a mistake, reach out to an administrator of the website and recreate your account after this account has been deleted. You may choose to complete account deletion at this time."
     }
 }

--- a/public/locales/en/administration.json
+++ b/public/locales/en/administration.json
@@ -113,7 +113,8 @@
         "confirmChange": "Confirm Admin Status Change"
     }, 
     "deletedAccount": {
+        "heading": "Notice: Account Deleted",
         "deleteNow": "Finish Account Deletion Now",
-        "explanation": "Your account has been deleted by an administrator of the website, and the account will be deleted within the next 24 hours. If you believe this is a mistake, reach out to an administrator of the website and recreate your account after this account has been deleted. You may choose to complete account deletion at this time."
+        "explanation": "Your account has been marked for deletion by an administrator of the website, and the account will be completely deleted within the next 24 hours. If you believe this is a mistake, reach out to an administrator of the website and recreate your account after this account has been deleted. You may choose to finish deleting your account now by clicking the 'Finish Account Deletion Now' button."
     }
 }

--- a/public/locales/es/administration.json
+++ b/public/locales/es/administration.json
@@ -113,7 +113,8 @@
         "confirmChange": "Confirma el cambio de status de administrador"
     }, 
     "deletedAccount": {
-        "deleteNow": "Finalizar la eliminación de la cuenta ahora",
-        "explanation": "Un administrador del sitio web ha eliminado tu cuenta y la cuenta se eliminará en las próximas 24 horas. Si crees que se trata de un error, comunícate con un administrador del sitio web y vuelve a crear tu cuenta después de que esta se haya eliminado. Puedes optar por completar la eliminación de la cuenta en este momento."
+        "heading": "Aviso: cuenta eliminada",
+        "deleteNow": "Finalizar la supresión de la cuenta ahora",
+        "explanation": "Un administrador del sitio web ha borrado tu cuenta y la cuenta se borrará en las próximas 24 horas. Si crees que se trata de un error, comunícate con un administrador del sitio web y vuelve a crear tu cuenta después de que esta se haya borrado. Puedes optar por finalizar de borrar tu cuenta ahora haciendo clic en el botón 'Finalizar supresión de cuenta ahora'."
     }
 }

--- a/public/locales/es/administration.json
+++ b/public/locales/es/administration.json
@@ -51,7 +51,6 @@
         "email": "Inscríbete por correo electrónico"
     },
     "signOut": "Cierra sesión",
-    "signOutError": "Al tratar de cerrar la sesión, ha ocurrido un error. Por favor, vuelve a intentar",
     "pageHeader": {
         "signIn": "Inicia Sesión",
         "signUp": "Inscríbete"
@@ -112,5 +111,9 @@
         },
         "changeAdminError": "No se puede cambiar el status de administrador(a) de ",
         "confirmChange": "Confirma el cambio de status de administrador"
+    }, 
+    "deletedAccount": {
+        "deleteNow": "Finalizar la eliminación de la cuenta ahora",
+        "explanation": "Un administrador del sitio web ha eliminado tu cuenta y la cuenta se eliminará en las próximas 24 horas. Si crees que se trata de un error, comunícate con un administrador del sitio web y vuelve a crear tu cuenta después de que esta se haya eliminado. Puedes optar por completar la eliminación de la cuenta en este momento."
     }
 }

--- a/src/components/Admin/AccountDeleted.tsx
+++ b/src/components/Admin/AccountDeleted.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import {Box, Flex, Button, Text} from '@chakra-ui/react';
 import {firebaseAuth} from '../../firebase/firebase';
 import SignOut from './Authentication/SignOut';
+import {useTranslation} from 'react-i18next';
 
 const AccountDeleted: () => JSX.Element = () => {
-  const deleteMessage =
-    'Your account has been deleted by an administrator of the website, and the account will be deleted within the next 24 hours. If you believe this is a mistake, reach out to an administrator of the website and recreate your account after this account has been deleted. You may choose to complete account deletion at this time.';
+  const {t} = useTranslation('administration');
 
   function deleteAccount(): Promise<void> {
     if (firebaseAuth.currentUser) {
@@ -19,7 +19,7 @@ const AccountDeleted: () => JSX.Element = () => {
     <Flex width="full" align="center" justifyContent="center">
       <Box
         padding={8}
-        margin={8}
+        marginX={8}
         width="full"
         maxWidth="500px"
         borderWidth={1}
@@ -27,9 +27,9 @@ const AccountDeleted: () => JSX.Element = () => {
         boxShadow="lg"
         textAlign="center"
       >
-        <Text>{deleteMessage}</Text>
+        <Text>{t('deletedAccount.explanation')}</Text>
         <Button onClick={deleteAccount} marginTop={2} colorScheme="red">
-          Complete Account Deletion Now
+          {t('deletedAccount.deleteNow')}
         </Button>
         <SignOut />
       </Box>

--- a/src/components/Admin/AccountDeleted.tsx
+++ b/src/components/Admin/AccountDeleted.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import {Box, Flex, Button, Text} from '@chakra-ui/react';
+import {firebaseAuth} from '../../firebase/firebase';
+import SignOut from './Authentication/SignOut';
+
+const AccountDeleted: () => JSX.Element = () => {
+  const deleteMessage =
+    'Your account has been deleted by an administrator of the website, and the account will be deleted within the next 24 hours. If you believe this is a mistake, reach out to an administrator of the website and recreate your account after this account has been deleted. You may choose to complete account deletion at this time.';
+
+  function deleteAccount(): Promise<void> {
+    if (firebaseAuth.currentUser) {
+      return firebaseAuth.currentUser.delete();
+    } else {
+      return firebaseAuth.signOut();
+    }
+  }
+
+  return (
+    <Flex width="full" align="center" justifyContent="center">
+      <Box
+        padding={8}
+        margin={8}
+        width="full"
+        maxWidth="500px"
+        borderWidth={1}
+        borderRadius={8}
+        boxShadow="lg"
+        textAlign="center"
+      >
+        <Text>{deleteMessage}</Text>
+        <Button onClick={deleteAccount} marginTop={2} colorScheme="red">
+          Complete Account Deletion Now
+        </Button>
+        <SignOut />
+      </Box>
+    </Flex>
+  );
+};
+
+export {AccountDeleted};

--- a/src/components/Admin/AccountDeleted.tsx
+++ b/src/components/Admin/AccountDeleted.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Box, Flex, Button, Text} from '@chakra-ui/react';
+import {Box, Flex, Button, Text, Heading} from '@chakra-ui/react';
 import {firebaseAuth} from '../../firebase/firebase';
 import SignOut from './Authentication/SignOut';
 import {useTranslation} from 'react-i18next';
@@ -27,6 +27,7 @@ const AccountDeleted: () => JSX.Element = () => {
         boxShadow="lg"
         textAlign="center"
       >
+        <Heading>{t('deletedAccount.heading')}</Heading>
         <Text>{t('deletedAccount.explanation')}</Text>
         <Button onClick={deleteAccount} marginTop={2} colorScheme="red">
           {t('deletedAccount.deleteNow')}

--- a/src/components/Admin/AuthenticatedAdmin.tsx
+++ b/src/components/Admin/AuthenticatedAdmin.tsx
@@ -3,16 +3,21 @@ import SignOut from './Authentication/SignOut';
 import {Heading, Box, Flex, Button} from '@chakra-ui/react';
 import {useAuth} from '../../contexts/AuthContext';
 import {useTranslation} from 'react-i18next';
+import {AccountDeleted} from './AccountDeleted';
 
 /**
  * Admin component for authenticated users.
  */
 const AuthenticatedAdmin: () => JSX.Element = () => {
   // --------------- State maintenance variables ------------------------
-  const {isAdmin} = useAuth();
+  const {isAdmin, isDeleted} = useAuth();
   // --------------- End state maintenance variables ------------------------
 
   const {t} = useTranslation('administration');
+
+  if (isDeleted) {
+    return <AccountDeleted />;
+  }
 
   return (
     <Flex width="full" align="center" justifyContent="center">

--- a/src/components/Admin/Authentication/SignOut.tsx
+++ b/src/components/Admin/Authentication/SignOut.tsx
@@ -4,24 +4,17 @@ import {firebaseAuth} from '../../../firebase/firebase';
 import {useTranslation} from 'react-i18next';
 
 /**
- * Button that signs the user out
+ * Button that signs the user out when clicked
  */
 const SignOut: () => JSX.Element = () => {
   const {t} = useTranslation('administration');
-  /**
-   * Signs out the user and sets authentication status to false.
-   * @param event - submit form event
-   */
-  function handleSignOut(): Promise<void> {
-    return firebaseAuth.signOut();
-  }
 
   return (
     <Box justifyContent="center">
       <Button
         minWidth="50%"
         marginY={4}
-        onClick={handleSignOut}
+        onClick={() => firebaseAuth.signOut()}
         colorScheme="red"
       >
         {t('signOut')}

--- a/src/components/Admin/Authentication/SignOut.tsx
+++ b/src/components/Admin/Authentication/SignOut.tsx
@@ -12,7 +12,7 @@ const SignOut: () => JSX.Element = () => {
    * Signs out the user and sets authentication status to false.
    * @param event - submit form event
    */
-   function handleSignOut(): Promise<void> {
+  function handleSignOut(): Promise<void> {
     return firebaseAuth.signOut();
   }
 
@@ -23,7 +23,7 @@ const SignOut: () => JSX.Element = () => {
         marginY={4}
         onClick={handleSignOut}
         colorScheme="red"
-        >
+      >
         {t('signOut')}
       </Button>
     </Box>

--- a/src/components/Admin/Authentication/SignOut.tsx
+++ b/src/components/Admin/Authentication/SignOut.tsx
@@ -1,5 +1,5 @@
-import React, {useState} from 'react';
-import {SubmitButton} from '../ComponentUtil';
+import React from 'react';
+import {Button, Box} from '@chakra-ui/react';
 import {firebaseAuth} from '../../../firebase/firebase';
 import {useTranslation} from 'react-i18next';
 
@@ -7,31 +7,26 @@ import {useTranslation} from 'react-i18next';
  * Button that signs the user out
  */
 const SignOut: () => JSX.Element = () => {
-  const [error, setError] = useState('');
   const {t} = useTranslation('administration');
   /**
    * Signs out the user and sets authentication status to false.
    * @param event - submit form event
    */
-  async function handleSignOut(event: React.FormEvent<HTMLFormElement>) {
-    // Prevents submission before sign out is complete
-    event.preventDefault();
-
-    try {
-      await firebaseAuth.signOut();
-    } catch {
-      setError(t('signOutError'));
-    }
+   function handleSignOut(): Promise<void> {
+    return firebaseAuth.signOut();
   }
 
   return (
-    <form onSubmit={handleSignOut}>
-      <SubmitButton
-        label={t('signOut')}
-        color={'red'}
-        error={error}
-      ></SubmitButton>
-    </form>
+    <Box justifyContent="center">
+      <Button
+        minWidth="50%"
+        marginY={4}
+        onClick={handleSignOut}
+        colorScheme="red"
+        >
+        {t('signOut')}
+      </Button>
+    </Box>
   );
 };
 

--- a/src/components/Admin/ManageAccount/ManageAccount.tsx
+++ b/src/components/Admin/ManageAccount/ManageAccount.tsx
@@ -7,6 +7,7 @@ import {firebaseAuth} from '../../../firebase/firebase';
 import Loading from '../../Util/Loading';
 import ChangeNameModal from './ChangeName';
 import {useTranslation} from 'react-i18next';
+import {AccountDeleted} from '../AccountDeleted';
 
 /**
  * Component for a user to manage their own account information.
@@ -19,6 +20,7 @@ const ManageAccount: () => JSX.Element = () => {
     isLoading: fetchingAuthContext,
     name,
     email,
+    isDeleted,
   } = useAuth();
   const [isLoading, setIsLoading] = useState(false);
   const [passwordUser, setPasswordUser] = useState(false);
@@ -56,6 +58,8 @@ const ManageAccount: () => JSX.Element = () => {
     return <Loading />;
   } else if (!isAuthenticated) {
     return <AccessDenied reason={t('notSignedIn')} />;
+  } else if (isDeleted) {
+    return <AccountDeleted />;
   } else {
     return (
       <Flex width="full" align="center" justifyContent="center">
@@ -70,16 +74,16 @@ const ManageAccount: () => JSX.Element = () => {
           textAlign="center"
         >
           <Heading marginBottom={2}>{t('manageAccount.heading')}</Heading>
-          <Text textAlign="left" fontSize="lg" fontWeight="bold">
+          <Heading textAlign="left" fontSize="lg" as="h2">
             {t('email')}
-          </Text>
+          </Heading>
           <Text textAlign="left" fontSize="md">
             {email}
           </Text>
           <Divider marginY={2} />
-          <Text textAlign="left" fontSize="lg" fontWeight="bold">
+          <Heading textAlign="left" fontSize="lg" as="h2">
             {t('name')}
-          </Text>
+          </Heading>
           <Text
             color={name ? 'black.500' : 'red.500'}
             textAlign="left"
@@ -89,9 +93,9 @@ const ManageAccount: () => JSX.Element = () => {
           </Text>
           <ChangeNameModal passwordUser={passwordUser} />
           <Divider marginY={2} />
-          <Text marginTop={2} fontSize="lg" fontWeight="bold" textAlign="left">
+          <Heading marginTop={2} fontSize="lg" as="h2" textAlign="left">
             {t('manageAccount.manageSignInMethodsHeader')}
-          </Text>
+          </Heading>
           {passwordUser && <ChangePasswordModal />}
           {googleUser && <Text>{t('manageAccount.connectedToGoogle')}</Text>}
           <Divider marginY={2} />

--- a/src/components/Admin/ManageUsers/ToggleUserPopover.tsx
+++ b/src/components/Admin/ManageUsers/ToggleUserPopover.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import {
+  Heading,
+  Button,
+  Text,
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  PopoverArrow,
+  PopoverCloseButton,
+  PopoverHeader,
+  PopoverBody,
+  Center,
+} from '@chakra-ui/react';
+import {User, ToggleUserPopoverProps} from './Types';
+import {firebaseAuth, firestore} from '../../../firebase/firebase';
+import {useTranslation} from 'react-i18next';
+import {useAuth} from '../../../contexts/AuthContext';
+
+/**
+ * Creates a button that when clicked, creates a confirmation popup to change
+ * a user's status. If a user tries to remove their own admin status, a
+ * warning is shown that the action cannot be undone without another admin
+ * user changing their status back.
+ * @param user - The current user for a row
+ * @param isLastAdmin - if there is only one remaining admin user
+ * @param setError - the setter for an error state
+ * @returns button that when clicked, creates a popover where an admin user can click to toggle that user's admin status
+ */
+const ToggleUserPopover: ({
+  user,
+  isLastAdmin,
+  setError,
+}: ToggleUserPopoverProps) => JSX.Element = ({
+  user,
+  isLastAdmin,
+  setError,
+}: ToggleUserPopoverProps) => {
+  const {isAdmin} = useAuth();
+  const {t} = useTranslation(['administration', 'common']);
+
+  /**
+   *
+   * @param event - click button event
+   * @param user - user for which to toggle admin status
+   */
+  function toggleAdminStatus(
+    event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+    user: User
+  ) {
+    event.preventDefault();
+
+    if (isAdmin) {
+      firestore
+        .collection('users')
+        .doc(user.userId)
+        .update({
+          admin: !user.admin,
+        })
+        .catch(() => {
+          setError(t('users.changeAdminError') + user.name);
+        });
+    }
+  }
+  const popoverMessage = user.admin
+    ? t('users.removeAdmin.confirmStart') +
+      user.name +
+      t('users.removeAdmin.confirmEnd')
+    : t('users.makeAdmin.confirmStart') +
+      user.name +
+      t('users.makeAdmin.confirmEnd');
+
+  const isSelf = user.userId === firebaseAuth.currentUser?.uid;
+
+  return (
+    <Popover>
+      <PopoverTrigger>
+        <Button
+          colorScheme={user.admin ? 'red' : 'green'}
+          width="full"
+          isDisabled={isLastAdmin && user.admin}
+        >
+          {user.admin
+            ? t('users.removeAdmin.button')
+            : t('users.makeAdmin.button')}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent>
+        <PopoverArrow />
+        <PopoverCloseButton />
+        <PopoverHeader>
+          <Heading fontSize="medium">{t('users.confirmChange')}</Heading>
+        </PopoverHeader>
+        <PopoverBody>
+          <Text>{popoverMessage}</Text>
+          {isSelf && (
+            <Text color="red.500">{t('users.removeAdmin.cannotBeUndone')}</Text>
+          )}
+          <Center>
+            <Button
+              paddingY={2}
+              colorScheme={user.admin ? 'red' : 'green'}
+              onClick={event => toggleAdminStatus(event, user)}
+            >
+              {t('common:confirm')}
+            </Button>
+          </Center>
+        </PopoverBody>
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+export {ToggleUserPopover};

--- a/src/components/Admin/ManageUsers/Types.ts
+++ b/src/components/Admin/ManageUsers/Types.ts
@@ -10,10 +10,14 @@ interface User {
 
 /**
  * Interface for ToggleUserPopover used for type safety
+ * - `user` - the user to toggle admin status for
+ * - `isLastAdmin` - if the signed in admin user is the last admin
+ * - `setError` - setter for error state
  */
 interface ToggleUserPopoverProps {
   user: User;
   isLastAdmin: boolean;
+  setError: React.Dispatch<React.SetStateAction<string>>;
 }
 
 export type {User, ToggleUserPopoverProps};

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -10,6 +10,7 @@ import {Props} from './AppProviders';
  * - `isAdmin` if user is an admin
  * - `name` user's name or empty string
  * - `email` user's email
+ * - `isDeleted` if a user's account is scheduled for deletion
  */
 interface AuthInterface {
   isAuthenticated: boolean;
@@ -17,6 +18,7 @@ interface AuthInterface {
   isAdmin: boolean;
   name: string;
   email: string;
+  isDeleted: boolean;
 }
 
 /**
@@ -36,6 +38,7 @@ const AuthProvider: React.FC<Props> = ({children}: Props) => {
   const [isLoading, setIsLoading] = useState(false);
   const [email, setEmail] = useState('');
   const [name, setName] = useState('');
+  const [isDeleted, setIsDeleted] = useState(false);
   // --------------- End state maintenance variables ------------------------
 
   /**
@@ -45,6 +48,7 @@ const AuthProvider: React.FC<Props> = ({children}: Props) => {
     setIsAdmin(false);
     setEmail('');
     setName('');
+    setIsDeleted(false);
   }
 
   useEffect(() => {
@@ -81,10 +85,14 @@ const AuthProvider: React.FC<Props> = ({children}: Props) => {
             const userData = snapshot.data();
 
             if (userData) {
-              if (typeof userData.admin === 'boolean')
+              if (typeof userData.admin === 'boolean') {
                 setIsAdmin(userData.admin);
+              }
               if (typeof userData.name === 'string') setName(userData.name);
               if (typeof userData.email === 'string') setEmail(userData.email);
+              if (typeof userData.isDeleted === 'boolean') {
+                setIsDeleted(userData.isDeleted);
+              }
             }
             setIsLoading(false);
           } else {
@@ -94,6 +102,7 @@ const AuthProvider: React.FC<Props> = ({children}: Props) => {
               name: user.displayName ?? '',
               email: user.email ?? '',
               admin: false,
+              isDeleted: false,
             };
             firestore
               .collection('users')
@@ -119,6 +128,7 @@ const AuthProvider: React.FC<Props> = ({children}: Props) => {
         isLoading: isLoading,
         name: name,
         email: email,
+        isDeleted: isDeleted,
       }}
     >
       {children}
@@ -128,7 +138,7 @@ const AuthProvider: React.FC<Props> = ({children}: Props) => {
 
 /**
  * Custom hook to allow other components to use authentication status
- * @returns `{isAuthenticated, isLoading, isAdmin, name, email}`
+ * @returns `{isAuthenticated, isLoading, isAdmin, name, email, isDeleted}`
  */
 const useAuth: () => AuthInterface = () => useContext(AuthContext);
 


### PR DESCRIPTION
When a user's account has been marked as `isDeleted` (which happens when an admin deletes a user's account), there's a period of 24 hours where the user could still be able to log in even though the account is deleted. This PR adds a page that's displayed to a user in this case.

You can test this PR locally by manually changing one of your non-admin accounts to `isDeleted=true` in Firestore. The next PRs will include functionality to set this as true.

This PR also:

- Moves the ToggleUserPopover to its own component
- Updates SignOut because I was getting some compilation errors
- Updates the user page headings to be "h2" elements