### PR TITLE
Implement ability for a non-admin user to delete themself

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -149,7 +149,8 @@
           "Merriweather",
           "semibold",
           "booleans",
-          "Subcollection"
+          "Subcollection",
+          "Reauthenticate"
         ],
         "skipWords": [
           "Pv"

--- a/public/locales/en/administration.json
+++ b/public/locales/en/administration.json
@@ -116,5 +116,11 @@
         "heading": "Notice: Account Deleted",
         "deleteNow": "Finish Account Deletion Now",
         "explanation": "Your account has been marked for deletion by an administrator of the website, and the account will be completely deleted within the next 24 hours. If you believe this is a mistake, reach out to an administrator of the website and recreate your account after this account has been deleted. You may choose to finish deleting your account now by clicking the 'Finish Account Deletion Now' button."
+    },
+    "deleteAccount": {
+        "heading": "Delete Account",
+        "error": "Unable to finish account deletion. Please try again later.",
+        "noAdminDelete": "You must remove yourself as an admin user before deleting your account.",
+        "confirmQuestion": "Are you sure that you want to delete your account? This action is permanent."
     }
 }

--- a/public/locales/es/administration.json
+++ b/public/locales/es/administration.json
@@ -116,5 +116,11 @@
         "heading": "Aviso: cuenta eliminada",
         "deleteNow": "Finalizar la supresión de la cuenta ahora",
         "explanation": "Un administrador del sitio web ha borrado tu cuenta y la cuenta se borrará en las próximas 24 horas. Si crees que se trata de un error, comunícate con un administrador del sitio web y vuelve a crear tu cuenta después de que esta se haya borrado. Puedes optar por finalizar de borrar tu cuenta ahora haciendo clic en el botón 'Finalizar supresión de cuenta ahora'."
+    },
+    "deleteAccount": {
+        "heading": "Borrar cuenta",
+        "error": "No se pudo finalizar el borrado de cuenta. Por favor, inténtalo de nuevo más tarde.",
+        "noAdminDelete": "Debes eliminarte como usuario administrador antes de eliminar tu cuenta.",
+        "confirmQuestion": "¿Estás seguro de que deseas eliminar tu cuenta? Esta acción es permanente."
     }
 }

--- a/src/components/Admin/ManageAccount/DeleteAccountPopover.tsx
+++ b/src/components/Admin/ManageAccount/DeleteAccountPopover.tsx
@@ -71,10 +71,12 @@ const DeleteAccountPopover: ({
    */
   function markUserDocAsDeleted(): Promise<void> {
     if (firebaseAuth.currentUser) {
-      return firestore.collection('users').doc(firebaseAuth.currentUser.uid)
-      .update({
-        isDeleted: true
-      });
+      return firestore
+        .collection('users')
+        .doc(firebaseAuth.currentUser.uid)
+        .update({
+          isDeleted: true,
+        });
     } else {
       return firebaseAuth.signOut();
     }

--- a/src/components/Admin/ManageAccount/DeleteAccountPopover.tsx
+++ b/src/components/Admin/ManageAccount/DeleteAccountPopover.tsx
@@ -1,0 +1,196 @@
+import React, {useState} from 'react';
+import {
+  Popover,
+  PopoverTrigger,
+  Button,
+  Portal,
+  PopoverArrow,
+  PopoverContent,
+  PopoverHeader,
+  PopoverCloseButton,
+  PopoverBody,
+  Text,
+  Heading,
+  Flex,
+  HStack,
+  Center,
+  Box,
+} from '@chakra-ui/react';
+import {WarningTwoIcon} from '@chakra-ui/icons';
+import firebase, {firebaseAuth, firestore} from '../../../firebase/firebase';
+import {handleReauthenticationWithPassword} from './Util';
+import {useTranslation} from 'react-i18next';
+import {PasswordFormInput} from '../ComponentUtil';
+import {useAuth} from '../../../contexts/AuthContext';
+
+/**
+ * Props for DeleteAccountPopover component. Used for type safety.
+ */
+interface DeleteAccountPopoverProps {
+  passwordUser: boolean;
+}
+
+/**
+ * @returns
+ */
+const DeleteAccountPopover: ({
+  passwordUser,
+}: DeleteAccountPopoverProps) => JSX.Element = ({
+  passwordUser,
+}: DeleteAccountPopoverProps) => {
+  const [password, setPassword] = useState('');
+  const [passwordVisible, setPasswordVisible] = useState(false);
+  const [passwordError, setPasswordError] = useState('');
+
+  const {isAdmin} = useAuth();
+
+  const [error, setError] = useState('');
+  const {t} = useTranslation(['administration', 'common']);
+
+  // For a password user, do not allow submission until they have entered a
+  // a password and there is no current password error. If the user enters the
+  // wrong password, the reauthenticate function will set the password error.
+  const passwordUserReadyToSubmit: boolean =
+    password !== '' && passwordError === '';
+
+  // Admins are not allowed to delete their account, so an admin user must
+  // remove themself as an admin before deleting their account. This prevents
+  // the last admin user from deleting their account since an admin cannot
+  // remove their admin status if they are the last admin.
+  const readyToDelete: boolean =
+    error === '' &&
+    !isAdmin &&
+    (passwordUser ? passwordUserReadyToSubmit : true);
+
+  /**
+   * Mark a user's doc for deletion in the `DELETION` collection.
+   * @returns a promise that when resolved means that the user's uid has been added to the user deletion doc
+   * @remarks We don't delete the user doc immediately because it will just be recreated while the user is signed in.
+   */
+  function markUserDocForDeletion(): Promise<void> {
+    if (firebaseAuth.currentUser) {
+      return firestore
+        .collection('deletion')
+        .doc('users')
+        .update({
+          userDocs: firebase.firestore.FieldValue.arrayUnion(
+            firebaseAuth.currentUser.uid
+          ),
+        })
+        .catch(() => setError(t('deleteAccount.error')));
+    } else {
+      return firebaseAuth.signOut();
+    }
+  }
+
+  /**
+   * Marks a user's doc in Firestore for deletion and then deletes the Firebase
+   * Authentication account for the signed in user.
+   * @returns a promise that when resolved means that a user's account has been deleted
+   */
+  function deleteAccount(): Promise<void> {
+    return markUserDocForDeletion()
+      .then(() => {
+        if (firebaseAuth.currentUser) {
+          firebaseAuth.currentUser.delete();
+        }
+      })
+      .catch(() => {
+        setError(t('deleteAccount.error'));
+      });
+  }
+
+  /**
+   * Reauthenticate a user by password if the user is password based and then delete the user's account
+   * @returns a promise that when resolved, reauthenticates a user by password if needed and then deletes the user's account
+   */
+  function handleDeleteAccount(): Promise<void> {
+    // Verify that the inputted password is correct before proceeding
+    if (passwordUser) {
+      return handleReauthenticationWithPassword(password, t)
+        .then(error => {
+          if (error) {
+            // This error can be handled by the user
+            setPasswordError(error);
+          } else {
+            // No error, so proceed with account deletion
+            deleteAccount();
+          }
+        })
+        .catch(error => {
+          // Propagate the error, since this error cannot be handled by the user
+          throw new Error(error);
+        });
+    } else {
+      // If user is not a password-based user, proceed with deleting the account
+      return deleteAccount();
+    }
+  }
+
+  return (
+    <Popover>
+      <PopoverTrigger>
+        <Button colorScheme="red">{t('deleteAccount.heading')}</Button>
+      </PopoverTrigger>
+      <Portal>
+        <PopoverContent>
+          <PopoverArrow />
+          <PopoverHeader>
+            <Flex alignItems="center" justifyContent="center">
+              <HStack>
+                <WarningTwoIcon color="red.500" />
+                <Heading size="md" textAlign="center">
+                  {t('deleteAccount.heading')}
+                </Heading>
+                <WarningTwoIcon color="red.500" />
+              </HStack>
+            </Flex>
+          </PopoverHeader>
+          <PopoverCloseButton />
+          <PopoverBody>
+            {isAdmin ? (
+              <Text textColor="red.500">
+                {t('deleteAccount.noAdminDelete')}
+              </Text>
+            ) : (
+              <Box>
+                {passwordUser && (
+                  <PasswordFormInput
+                    label={t('password')}
+                    handlePasswordChange={event => {
+                      setPassword(event.target.value);
+                      setError('');
+                      setPasswordError('');
+                    }}
+                    showPassword={passwordVisible}
+                    handlePasswordVisibility={() => {
+                      setPasswordVisible(!passwordVisible);
+                    }}
+                    error={passwordError}
+                    value={password}
+                    helpMessage={t('passwordHelpMessage')}
+                  />
+                )}
+                <Text marginY={2} fontWeight="bold">
+                  {t('deleteAccount.confirmQuestion')}
+                </Text>
+                <Center>
+                  <Button
+                    isDisabled={!readyToDelete}
+                    colorScheme="red"
+                    onClick={handleDeleteAccount}
+                  >
+                    {t('common:confirm')}
+                  </Button>
+                </Center>
+                <Text textColor="red.500">{error}</Text>
+              </Box>
+            )}
+          </PopoverBody>
+        </PopoverContent>
+      </Portal>
+    </Popover>
+  );
+};
+
+export {DeleteAccountPopover};

--- a/src/components/Admin/ManageAccount/ManageAccount.tsx
+++ b/src/components/Admin/ManageAccount/ManageAccount.tsx
@@ -8,6 +8,7 @@ import Loading from '../../Util/Loading';
 import ChangeNameModal from './ChangeName';
 import {useTranslation} from 'react-i18next';
 import {AccountDeleted} from '../AccountDeleted';
+import {DeleteAccountPopover} from './DeleteAccountPopover';
 
 /**
  * Component for a user to manage their own account information.
@@ -98,6 +99,11 @@ const ManageAccount: () => JSX.Element = () => {
           </Heading>
           {passwordUser && <ChangePasswordModal />}
           {googleUser && <Text>{t('manageAccount.connectedToGoogle')}</Text>}
+          <Divider marginY={2} />
+          <Heading fontSize="lg" as="h2" textAlign="left">
+            {t('deleteAccount.heading')}
+          </Heading>
+          <DeleteAccountPopover passwordUser={passwordUser} />
           <Divider marginY={2} />
           <Text color="red.500">{error}</Text>
           <Button as="a" href="/admin" margin={1}>


### PR DESCRIPTION
This creates a section on the user page where a user can delete themself. An admin user must remove themself as an admin before deleting their account. This protects the admin side of the site since if an admin is the last admin, they cannot remove their admin status.

This works in the backend by labeling a user's doc for deletion in the `deletion` collection and then deleting a user's Firebase Authentication account. We delete the user doc in the backend because:

- If we delete the user doc before deleting the Firebase Authentication account, the AuthContext will detect that a user is signed in without a user doc, and it will create one.
- We need the user's uid to delete their user doc, so if we delete their Firebase Authentication account first, the user is signed out and we can't access their user ID (or auth status) to be able to delete the doc in Firestore.