### PR TITLE
Update Firestore rules to check fields updated

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -68,26 +68,33 @@ service cloud.firestore {
 
     // Used for deletion of user data
     match /deletion/users {
-      // Verify that a (1) user is signed in, (2) the only modified field is
+      let newData = request.resource.data;
+      let oldData = resource.data;
+
+      // Verify that (1) user is signed in, (2) the only modified field is
       // userDocs, (3) the userDocs array is increased in size by only 1,
       // and (4) the added item from the userDocs array is the user's uid.
       function addUidToUserDocs() {
-        let onlyUserDocsUpdated = request.resource.data.keys().hasOnly('userDocs');
-        let oneItemRemoved = request.resource.data.users.size() == resource.data.users.size() + 1;
-        let addedUid = request.resource.data.users.removeAll(resource.data.users)[0] == request.auth.uid;
+        // The diff() function combined with affectedKeys() returns a list of
+        // keys that were changed in an update operation
+        let onlyUserDocsUpdated = newData.diff(oldData).affectedKeys().hasOnly('userDocs');
+        let oneItemAdded = newData.userDocs.size() == oldData.userDocs.size() + 1;
+        let addedUid = newData.userDocs.removeAll(oldData.userDocs)[0] == request.auth.uid;
         return isSignedIn()
                 && onlyUserDocsUpdated
-                && oneItemRemoved
+                && oneItemAdded
                 && addedUid;
       }
 
-      // Verify that a (1) user is signed in, (2) the only modified field is
+      // Verify that (1) user is signed in, (2) the only modified field is
       // firebaseUsers, (3) the firebaseUsers array is reduced in size by only 1,
       // and (4) the removed item from the firebaseUsers array is the user's uid.
       function removeUidFromFirebaseUsers() {
-        let onlyFirebaseUsersUpdated = request.resource.data.keys().hasOnly('firebaseUsers');
-        let oneItemRemoved = request.resource.data.users.size() == resource.data.users.size() - 1;
-        let removedUid = resource.data.users.removeAll(request.resource.data.users)[0] == request.auth.uid;
+        // The diff() function combined with affectedKeys() returns a list of
+        // keys that were changed in an update operation
+        let onlyFirebaseUsersUpdated = newData.diff(oldData).affectedKeys().hasOnly('firebaseUsers');
+        let oneItemRemoved = newData.firebaseUsers.size() == oldData.firebaseUsers.size() - 1;
+        let removedUid = oldData.firebaseUsers.removeAll(newData.firebaseUsers)[0] == request.auth.uid;
         return isSignedIn()
                 && onlyFirebaseUsersUpdated
                 && oneItemRemoved

--- a/firestore.rules
+++ b/firestore.rules
@@ -71,7 +71,7 @@ service cloud.firestore {
       // Verify that a (1) user is signed in, (2) the only modified field is
       // userDocs, (3) the userDocs array is increased in size by only 1,
       // and (4) the added item from the userDocs array is the user's uid.
-      function markingCurrentUserDoc() {
+      function addUidToUserDocs() {
         let onlyUserDocsUpdated = request.resource.data.keys().hasOnly('userDocs');
         let oneItemRemoved = request.resource.data.users.size() == resource.data.users.size() + 1;
         let addedUid = request.resource.data.users.removeAll(resource.data.users)[0] == request.auth.uid;
@@ -84,7 +84,7 @@ service cloud.firestore {
       // Verify that a (1) user is signed in, (2) the only modified field is
       // firebaseUsers, (3) the firebaseUsers array is reduced in size by only 1,
       // and (4) the removed item from the firebaseUsers array is the user's uid.
-      function removingCurrentUserId() {
+      function removeUidFromFirebaseUsers() {
         let onlyFirebaseUsersUpdated = request.resource.data.keys().hasOnly('firebaseUsers');
         let oneItemRemoved = request.resource.data.users.size() == resource.data.users.size() - 1;
         let removedUid = resource.data.users.removeAll(request.resource.data.users)[0] == request.auth.uid;
@@ -96,7 +96,7 @@ service cloud.firestore {
 
       // Admins can mark an account for deletion. General users can only mark
       // their own account for deletion.
-      allow write: if isAdmin() || markingCurrentUserDoc() || removingCurrentUserId();
+      allow write: if isAdmin() || addUidToUserDocs() || removeUidFromFirebaseUsers();
 
       // Only the Cloud Functions can read the deletion document
       allow read: if false;

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,6 +1,11 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
+    // Note that request.resource.data contains the incoming data update while
+    // resource.data is a map of all of the fields and values stored in the
+    // document.
+
+    // Check if a user is signed in
     function isSignedIn() {
       return request.auth != null;
     }
@@ -63,14 +68,35 @@ service cloud.firestore {
 
     // Used for deletion of user data
     match /deletion/users {
+      // Verify that a (1) user is signed in, (2) the only modified field is
+      // userDocs, (3) the userDocs array is increased in size by only 1,
+      // and (4) the added item from the userDocs array is the user's uid.
       function markingCurrentUserDoc() {
-        // Verify that the current user is adding their user ID to the userDocs field
-        return isSignedIn() && request.auth.uid in request.resource.data.userDocs;
+        let onlyUserDocsUpdated = request.resource.data.keys().hasOnly('userDocs');
+        let oneItemRemoved = request.resource.data.users.size() == resource.data.users.size() + 1;
+        let addedUid = request.resource.data.users.removeAll(resource.data.users)[0] == request.auth.uid;
+        return isSignedIn()
+                && onlyUserDocsUpdated
+                && oneItemRemoved
+                && addedUid;
       }
 
-      // Admins can mark an account for deletion. General users can only
-      // mark their own account for deletion.
-      allow write: if isAdmin() || markingCurrentUserDoc();
+      // Verify that a (1) user is signed in, (2) the only modified field is
+      // firebaseUsers, (3) the firebaseUsers array is reduced in size by only 1,
+      // and (4) the removed item from the firebaseUsers array is the user's uid.
+      function removingCurrentUserId() {
+        let onlyFirebaseUsersUpdated = request.resource.data.keys().hasOnly('firebaseUsers');
+        let oneItemRemoved = request.resource.data.users.size() == resource.data.users.size() - 1;
+        let removedUid = resource.data.users.removeAll(request.resource.data.users)[0] == request.auth.uid;
+        return isSignedIn()
+                && onlyFirebaseUsersUpdated
+                && oneItemRemoved
+                && removedUid;
+      }
+
+      // Admins can mark an account for deletion. General users can only mark
+      // their own account for deletion.
+      allow write: if isAdmin() || markingCurrentUserDoc() || removingCurrentUserId();
 
       // Only the Cloud Functions can read the deletion document
       allow read: if false;


### PR DESCRIPTION
If a user deletes their own account after an admin has marked their account for deletion, we have to remove the uid from the firebaseUsers list in the deletion collection. Otherwise, the deletion cloud function tries to delete a Firebase user that does not exist.

These Firestore rules allow these sorts of changes. For non-admin users, these rules check that only one field is modified and that the modification is either adding or removing their own user ID.