### PR TITLE
Fix Firestore Rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,6 +1,11 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
+    // Note that request.resource.data contains the incoming data update while
+    // resource.data is a map of all of the fields and values stored in the
+    // document.
+
+    // Check if a user is signed in
     function isSignedIn() {
       return request.auth != null;
     }
@@ -90,7 +95,7 @@ service cloud.firestore {
         // their own account for deletion.
         allow write: if isAdmin() || addUidToUserDocs(request.resource.data, resource.data) || removeUidFromFirebaseUsers(request.resource.data, resource.data);
 
-        // Only the Cloud Functions can read the deletion document
+        // Only the Cloud Functions can read the users document
         allow read: if false;
     }
   }

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,11 +1,6 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
-    // Note that request.resource.data contains the incoming data update while
-    // resource.data is a map of all of the fields and values stored in the
-    // document.
-
-    // Check if a user is signed in
     function isSignedIn() {
       return request.auth != null;
     }
@@ -57,56 +52,46 @@ service cloud.firestore {
       allow write: if false;
     }
 
-    // Used for scheduled deletion of sensor readings
-    match /deletion/readings {
-      // Admins can read the document for the purpose of merging data
-      allow read: if isAdmin();
+      // Used for deletion of user data
+      match /users {
 
-      // Admins can write to the todo document, which tells the backend what to delete
-      allow write: if isAdmin();
-    }
+        // Check that a field is not being updated.
+        function notUpdated(newData, oldData, field) {
+          return !(field in newData) || oldData[field] == newData[field]
+        }
 
-    // Used for deletion of user data
-    match /deletion/users {
-      let newData = request.resource.data;
-      let oldData = resource.data;
+        // Verify that (1) user is signed in, (2) the only modified field is
+        // userDocs, (3) the userDocs array is increased in size by only 1,
+        // and (4) the added item from the userDocs array is the user's uid.
+        function addUidToUserDocs(newData, oldData) {
+          let firebaseUsersNotUpdated = notUpdated(newData, oldData, 'firebaseUsers');
+          let oneItemAdded = newData['userDocs'].size() == oldData['userDocs'].size() + 1;
+          let addedUid = newData['userDocs'].removeAll(oldData['userDocs'])[0] == request.auth.uid;
+          return isSignedIn()
+                  && firebaseUsersNotUpdated
+                  && oneItemAdded
+                  && addedUid;
+        }
 
-      // Verify that (1) user is signed in, (2) the only modified field is
-      // userDocs, (3) the userDocs array is increased in size by only 1,
-      // and (4) the added item from the userDocs array is the user's uid.
-      function addUidToUserDocs() {
-        // The diff() function combined with affectedKeys() returns a list of
-        // keys that were changed in an update operation
-        let onlyUserDocsUpdated = newData.diff(oldData).affectedKeys().hasOnly('userDocs');
-        let oneItemAdded = newData.userDocs.size() == oldData.userDocs.size() + 1;
-        let addedUid = newData.userDocs.removeAll(oldData.userDocs)[0] == request.auth.uid;
-        return isSignedIn()
-                && onlyUserDocsUpdated
-                && oneItemAdded
-                && addedUid;
-      }
+        // Verify that (1) user is signed in, (2) the only modified field is
+        // firebaseUsers, (3) the firebaseUsers array is reduced in size by only 1,
+        // and (4) the removed item from the firebaseUsers array is the user's uid.
+        function removeUidFromFirebaseUsers(newData, oldData) {
+          let userDocsNotUpdated = notUpdated(newData, oldData, 'userDocs');
+          let oneItemRemoved = newData['firebaseUsers'].size() == oldData['firebaseUsers'].size() - 1;
+          let removedUid = oldData['firebaseUsers'].removeAll(newData['firebaseUsers'])[0] == request.auth.uid;
+          return isSignedIn()
+                  && userDocsNotUpdated
+                  && oneItemRemoved
+                  && removedUid;
+        }
 
-      // Verify that (1) user is signed in, (2) the only modified field is
-      // firebaseUsers, (3) the firebaseUsers array is reduced in size by only 1,
-      // and (4) the removed item from the firebaseUsers array is the user's uid.
-      function removeUidFromFirebaseUsers() {
-        // The diff() function combined with affectedKeys() returns a list of
-        // keys that were changed in an update operation
-        let onlyFirebaseUsersUpdated = newData.diff(oldData).affectedKeys().hasOnly('firebaseUsers');
-        let oneItemRemoved = newData.firebaseUsers.size() == oldData.firebaseUsers.size() - 1;
-        let removedUid = oldData.firebaseUsers.removeAll(newData.firebaseUsers)[0] == request.auth.uid;
-        return isSignedIn()
-                && onlyFirebaseUsersUpdated
-                && oneItemRemoved
-                && removedUid;
-      }
+        // Admins can mark an account for deletion. General users can only mark
+        // their own account for deletion.
+        allow write: if isAdmin() || addUidToUserDocs(request.resource.data, resource.data) || removeUidFromFirebaseUsers(request.resource.data, resource.data);
 
-      // Admins can mark an account for deletion. General users can only mark
-      // their own account for deletion.
-      allow write: if isAdmin() || addUidToUserDocs() || removeUidFromFirebaseUsers();
-
-      // Only the Cloud Functions can read the deletion document
-      allow read: if false;
+        // Only the Cloud Functions can read the deletion document
+        allow read: if false;
     }
   }
 }


### PR DESCRIPTION
This time, I checked that the rules compiled in Firestore and I accidentally deployed them there too.

This [blog post](https://dev.to/chinchang/restrict-specific-fields-updation-in-firebase-firestore-ohp) was really helpful for figuring out how to restrict updates to a field