### PR TITLE
Default to a sensor when the page opens

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -9,5 +9,6 @@
     "moreInformation": "More Information",
     "jumpTo": "Jump to",
     "aqiHelpHeading": "What Is AQI?",
-    "aqiHelpMessage": "AQI stands for Air Quality Index. It is the national standard for indicating how good or bad the air is. Lower numbers indicate safer air, while higher numbers indicate more hazardous air."
+    "aqiHelpMessage": "AQI stands for Air Quality Index. It is the national standard for indicating how good or bad the air is. Lower numbers indicate safer air, while higher numbers indicate more hazardous air.",
+    "noSensorGauge": "Click a sensor on the map to see its AQI value here!"
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -10,5 +10,5 @@
     "jumpTo": "Jump to",
     "aqiHelpHeading": "What Is AQI?",
     "aqiHelpMessage": "AQI stands for Air Quality Index. It is the national standard for indicating how good or bad the air is. Lower numbers indicate safer air, while higher numbers indicate more hazardous air.",
-    "noSensorGauge": "Click a sensor on the map to see its AQI value here!"
+    "instructions": "Click a sensor on the map to see its AQI value here!"
 }

--- a/public/locales/en/home.json
+++ b/public/locales/en/home.json
@@ -1,5 +1,4 @@
 {
-    "noSensorGauge": "Click a sensor on the map to see its AQI value here!",
     "dataVizBox": "Data Visualization Box",
     "expandMap": "Expand to see the sensor map",
     "expandAqiGauge": "Expand to see information about the selected sensor",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -10,5 +10,5 @@
     "jumpTo": "Salta a",
     "aqiHelpHeading": "¿Qué es AQI?",
     "aqiHelpMessage": "AQI es el índice de la calidad del aire. Es el estándar nacional para indicar si el aire está bien o mal. Los números más bajos indican aire más saludable, mientras que los números más altos indican aire más peligroso.",
-    "noSensorGauge": "¡Haz clic en un sensor en el mapa para ver el Índice de la calidad de aire (Air Quality Index, AQI) aquí!"
+    "instructions": "¡Haz clic en un sensor en el mapa para ver el Índice de la calidad de aire AQI aquí!"
 }

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -9,5 +9,6 @@
     "moreInformation": "Más información",
     "jumpTo": "Salta a",
     "aqiHelpHeading": "¿Qué es AQI?",
-    "aqiHelpMessage": "AQI es el índice de la calidad del aire. Es el estándar nacional para indicar si el aire está bien o mal. Los números más bajos indican aire más saludable, mientras que los números más altos indican aire más peligroso."
+    "aqiHelpMessage": "AQI es el índice de la calidad del aire. Es el estándar nacional para indicar si el aire está bien o mal. Los números más bajos indican aire más saludable, mientras que los números más altos indican aire más peligroso.",
+    "noSensorGauge": "¡Haz clic en un sensor en el mapa para ver el Índice de la calidad de aire (Air Quality Index, AQI) aquí!"
 }

--- a/public/locales/es/home.json
+++ b/public/locales/es/home.json
@@ -1,5 +1,4 @@
 {
-    "noSensorGauge": "¡Haz clic en un sensor en el mapa para ver el Índice de la calidad de aire (Air Quality Index, AQI) aquí!",
     "dataVizBox": "Cuadro de visualización de datos",
     "expandMap": "Expandir para ver el mapa de sensores",
     "expandAqiGauge": "Expandir para ver más información sobre el sensor elegido",

--- a/src/components/AqiGauge/AqiDial.tsx
+++ b/src/components/AqiGauge/AqiDial.tsx
@@ -103,7 +103,16 @@ const AqiDial: ({selectedSensor}: DialProps) => JSX.Element = ({
       >
         <Box>
           <Center flexDir="column">
-            <Text fontWeight="semibold">Sensor: {selectedSensor.name}</Text>
+            <MoreInfoLabel
+              fontFamily="Oxygen"
+              fontSize="lg"
+              text={t('common:noSensorGauge')}
+              popoverLabel={t('common:aqiHelpHeading')}
+              message={t('common:aqiHelpMessage')}
+            />
+            <Text marginTop={1} fontWeight="semibold">
+              Sensor: {selectedSensor.name}
+            </Text>
             <GaugeSvg currentAqi={selectedSensor.aqi} />
             <MoreInfoLabel
               fontWeight="bold"
@@ -134,7 +143,16 @@ const AqiDial: ({selectedSensor}: DialProps) => JSX.Element = ({
         fontFamily="Oxygen"
         flexDir="column"
       >
-        <Text fontWeight="semibold">Sensor: {selectedSensor.name}</Text>
+        <MoreInfoLabel
+          fontFamily="Oxygen"
+          fontSize="lg"
+          text={t('common:noSensorGauge')}
+          popoverLabel={t('common:aqiHelpHeading')}
+          message={t('common:aqiHelpMessage')}
+        />
+        <Text marginTop={1} fontWeight="semibold">
+          Sensor: {selectedSensor.name}
+        </Text>
         <InvalidSensor selectedSensor={selectedSensor} />
       </Flex>
     );

--- a/src/components/AqiGauge/AqiDial.tsx
+++ b/src/components/AqiGauge/AqiDial.tsx
@@ -106,7 +106,7 @@ const AqiDial: ({selectedSensor}: DialProps) => JSX.Element = ({
             <MoreInfoLabel
               fontFamily="Oxygen"
               fontSize="lg"
-              text={t('common:noSensorGauge')}
+              text={t('common:instructions')}
               popoverLabel={t('common:aqiHelpHeading')}
               message={t('common:aqiHelpMessage')}
             />
@@ -146,7 +146,7 @@ const AqiDial: ({selectedSensor}: DialProps) => JSX.Element = ({
         <MoreInfoLabel
           fontFamily="Oxygen"
           fontSize="lg"
-          text={t('common:noSensorGauge')}
+          text={t('common:instructions')}
           popoverLabel={t('common:aqiHelpHeading')}
           message={t('common:aqiHelpMessage')}
         />

--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -210,7 +210,17 @@ class Map extends React.Component<MapProps> {
               isValid: data.isValid,
               lastValidAqiTime: data.lastValidAqiTime,
             };
+            // Set selected sensor
             this.props.updateSelectedSensor(selectedSensor);
+            // Update icon of currently selected sensor
+            const updatedIcon = createSensorIcon(
+              data.aqi,
+              false,
+              true,
+              this.props.currentColorScheme,
+              data.isValid
+            );
+            firstSensor.setIcon(updatedIcon);
           }
         }
       }

--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -221,6 +221,8 @@ class Map extends React.Component<MapProps> {
               data.isValid
             );
             firstSensor.setIcon(updatedIcon);
+            // Update the state of the selected Sensor
+            this.setState({selectedSensor: firstSensor});
           }
         }
       }

--- a/src/pages/home/OnlineHome.tsx
+++ b/src/pages/home/OnlineHome.tsx
@@ -188,7 +188,7 @@ const OnlineHome: () => JSX.Element = () => {
                       fontFamily="Oxygen"
                       fontWeight="bold"
                       fontSize="lg"
-                      text={t('noSensorGauge')}
+                      text={t('common:noSensorGauge')}
                       popoverLabel={t('common:aqiHelpHeading')}
                       message={t('common:aqiHelpMessage')}
                     />

--- a/src/pages/home/OnlineHome.tsx
+++ b/src/pages/home/OnlineHome.tsx
@@ -188,7 +188,7 @@ const OnlineHome: () => JSX.Element = () => {
                       fontFamily="Oxygen"
                       fontWeight="bold"
                       fontSize="lg"
-                      text={t('common:noSensorGauge')}
+                      text={t('common:instructions')}
                       popoverLabel={t('common:aqiHelpHeading')}
                       message={t('common:aqiHelpMessage')}
                     />


### PR DESCRIPTION
I kept the default instructions on the home page to display while the map is loading (which for me is too fast to read it, but nice for people with weaker connection/slower browsers).

This closes #634 