### PR TITLE
Change mobile navbar threshold

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@chakra-ui/form-control": "^1.3.3",
     "@chakra-ui/icons": "^1.0.11",
     "@chakra-ui/react": "^1.5.2",
+    "@chakra-ui/theme-tools": "^1.1.5",
     "@emotion/react": "^11.1.5",
     "@emotion/styled": "^11.3.0",
     "@testing-library/jest-dom": "^5.11.10",

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -10,5 +10,5 @@
     "jumpTo": "Salta a",
     "aqiHelpHeading": "¿Qué es AQI?",
     "aqiHelpMessage": "AQI es el índice de la calidad del aire. Es el estándar nacional para indicar si el aire está bien o mal. Los números más bajos indican aire más saludable, mientras que los números más altos indican aire más peligroso.",
-    "instructions": "¡Haz clic en un sensor en el mapa para ver el Índice de la calidad de aire AQI aquí!"
+    "instructions": "¡Haz clic en un sensor en el mapa para ver el AQI aquí!"
 }

--- a/public/locales/es/dial.json
+++ b/public/locales/es/dial.json
@@ -1,6 +1,6 @@
 {
     "aqi": "Índice de la calidad del aire: ",
-    "moreInfo": "Para aprender más sobre la calidad del aire y el Índice de la calidad del aire (Air Quality Index, AQI), visita nuestra ",
+    "moreInfo": "Para aprender más sobre la calidad del aire y el AQI, visita nuestra ",
     "good": "Bueno (0-50)",
     "moderate": "Moderado (51-100)",
     "sensitive": "Insalubre para grupos sensibles (101-150)",

--- a/src/components/NavBar/NavigationBar.tsx
+++ b/src/components/NavBar/NavigationBar.tsx
@@ -10,7 +10,7 @@ import {useTranslation} from 'react-i18next';
  */
 function NavigationBar(): JSX.Element {
   const [isMobile, setIsMobile] = useState(
-    window.matchMedia('(max-width: 52em)')?.matches ?? false
+    window.matchMedia('(max-width: 55em)')?.matches ?? false
   );
   const [isOpen, setIsOpen] = useState(!isMobile);
   const [isScrolled, setIsScrolled] = useState(false);
@@ -49,7 +49,7 @@ function NavigationBar(): JSX.Element {
    * the window size is changed.
    */
   useEffect(() => {
-    const screenSize = window.matchMedia('(max-width: 52em)');
+    const screenSize = window.matchMedia('(max-width: 55em)');
     if (screenSize) {
       screenSize.addEventListener('change', handleScreenChange);
     }

--- a/src/components/NavBar/NavigationBar.tsx
+++ b/src/components/NavBar/NavigationBar.tsx
@@ -10,7 +10,7 @@ import {useTranslation} from 'react-i18next';
  */
 function NavigationBar(): JSX.Element {
   const [isMobile, setIsMobile] = useState(
-    window.matchMedia('(max-width: 47.9em)')?.matches ?? false
+    window.matchMedia('(max-width: 52em)')?.matches ?? false
   );
   const [isOpen, setIsOpen] = useState(!isMobile);
   const [isScrolled, setIsScrolled] = useState(false);
@@ -49,7 +49,7 @@ function NavigationBar(): JSX.Element {
    * the window size is changed.
    */
   useEffect(() => {
-    const screenSize = window.matchMedia('(max-width: 47.9em)');
+    const screenSize = window.matchMedia('(max-width: 52em)');
     if (screenSize) {
       screenSize.addEventListener('change', handleScreenChange);
     }
@@ -71,7 +71,7 @@ function NavigationBar(): JSX.Element {
     function handleScroll(): void {
       let scrollThreshold = 120;
       if (isMobile) {
-        /* eslint-disable-next-line no-magic-numbers */
+        // eslint-disable-next-line no-magic-numbers
         scrollThreshold = 800;
       }
       const offset = window.scrollY;

--- a/src/contexts/AppProviders.tsx
+++ b/src/contexts/AppProviders.tsx
@@ -2,6 +2,19 @@ import {ChakraProvider} from '@chakra-ui/react';
 import React from 'react';
 import {AuthProvider} from './AuthContext';
 import {ColorProvider} from './ColorContext';
+// 1. Import the utilities
+import {extendTheme} from '@chakra-ui/react';
+import {createBreakpoints} from '@chakra-ui/theme-tools';
+
+// 2. Update the breakpoints as key-value pairs
+const breakpoints = createBreakpoints({
+  sm: '30em',
+  md: '55em',
+  lg: '62em',
+  xl: '80em',
+});
+// 3. Extend the theme
+const theme = extendTheme({breakpoints});
 
 /**
  * Interface to type the children components of the Providers.
@@ -22,7 +35,7 @@ interface Props {
  */
 const AppProviders: React.FC<Props> = ({children}: Props) => {
   return (
-    <ChakraProvider>
+    <ChakraProvider theme={theme}>
       <ColorProvider>
         <AuthProvider>{children}</AuthProvider>
       </ColorProvider>

--- a/src/contexts/AppProviders.tsx
+++ b/src/contexts/AppProviders.tsx
@@ -2,18 +2,16 @@ import {ChakraProvider} from '@chakra-ui/react';
 import React from 'react';
 import {AuthProvider} from './AuthContext';
 import {ColorProvider} from './ColorContext';
-// 1. Import the utilities
 import {extendTheme} from '@chakra-ui/react';
 import {createBreakpoints} from '@chakra-ui/theme-tools';
 
-// 2. Update the breakpoints as key-value pairs
+// Create custom breakpoints for Chakra UI responsive styles
 const breakpoints = createBreakpoints({
   sm: '30em',
   md: '55em',
   lg: '62em',
   xl: '80em',
 });
-// 3. Extend the theme
 const theme = extendTheme({breakpoints});
 
 /**

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -23,7 +23,7 @@ import {BiDotsVerticalRounded} from 'react-icons/bi';
 
 const About: React.FC = () => {
   const [isMobile, setIsMobile] = useState(
-    window.matchMedia('(max-width: 47.9em)')?.matches ?? false
+    window.matchMedia('(max-width: 55em)')?.matches ?? false
   );
   // -------- Detect screen size for conditional formatting --------- //
   /**
@@ -44,7 +44,7 @@ const About: React.FC = () => {
 
   // Updates the state and the dom when the window size is changed
   useEffect(() => {
-    const screenSize = window.matchMedia('(max-width: 47.9em)');
+    const screenSize = window.matchMedia('(max-width: 55em)');
     if (screenSize) {
       screenSize.addEventListener('change', handleScreenChange);
     }

--- a/src/pages/Health.tsx
+++ b/src/pages/Health.tsx
@@ -22,7 +22,7 @@ import {Section} from '../components/Static/Section';
 const Health: React.FC = () => {
   const {t, i18n} = useTranslation(['health', 'common']);
   const [isMobile, setIsMobile] = useState(
-    window.matchMedia('(max-width: 47.9em)')?.matches ?? false
+    window.matchMedia('(max-width: 55em)')?.matches ?? false
   );
   // -------- Detect screen size for conditional formatting --------- //
   /**
@@ -43,7 +43,7 @@ const Health: React.FC = () => {
 
   // Updates the state and the dom when the window size is changed
   useEffect(() => {
-    const screenSize = window.matchMedia('(max-width: 47.9em)');
+    const screenSize = window.matchMedia('(max-width: 55em)');
     if (screenSize) {
       screenSize.addEventListener('change', handleScreenChange);
     }

--- a/src/pages/home/OnlineHome.tsx
+++ b/src/pages/home/OnlineHome.tsx
@@ -24,7 +24,7 @@ const OnlineHome: () => JSX.Element = () => {
     lastValidAqiTime: null,
   });
   const [isMobile, setIsMobile] = useState(
-    window.matchMedia('(max-width: 52em)')?.matches ?? false
+    window.matchMedia('(max-width: 55em)')?.matches ?? false
   );
   const [showGraphUi, setShowGraphUi] = useState(false);
   const [showGaugeUi, setShowGaugeUi] = useState(true);
@@ -50,7 +50,7 @@ const OnlineHome: () => JSX.Element = () => {
 
   // Updates the state and the dom when the window size is changed
   useEffect(() => {
-    const screenSize = window.matchMedia('(max-width: 52em)');
+    const screenSize = window.matchMedia('(max-width: 55em)');
     if (screenSize) {
       screenSize.addEventListener('change', handleScreenChange);
     }

--- a/src/pages/home/OnlineHome.tsx
+++ b/src/pages/home/OnlineHome.tsx
@@ -24,7 +24,7 @@ const OnlineHome: () => JSX.Element = () => {
     lastValidAqiTime: null,
   });
   const [isMobile, setIsMobile] = useState(
-    window.matchMedia('(max-width: 47.9em)')?.matches ?? false
+    window.matchMedia('(max-width: 52em)')?.matches ?? false
   );
   const [showGraphUi, setShowGraphUi] = useState(false);
   const [showGaugeUi, setShowGaugeUi] = useState(true);
@@ -41,7 +41,7 @@ const OnlineHome: () => JSX.Element = () => {
   function handleScreenChange(this: MediaQueryList): void {
     // Is the screen size mobile size
     if (this.matches) {
-      // True when the screen-width is at most 47.9em
+      // True when the screen-width is at most 52em
       setIsMobile(true);
     } else {
       setIsMobile(false);
@@ -50,7 +50,7 @@ const OnlineHome: () => JSX.Element = () => {
 
   // Updates the state and the dom when the window size is changed
   useEffect(() => {
-    const screenSize = window.matchMedia('(max-width: 47.9em)');
+    const screenSize = window.matchMedia('(max-width: 52em)');
     if (screenSize) {
       screenSize.addEventListener('change', handleScreenChange);
     }

--- a/src/pages/home/OnlineHome.tsx
+++ b/src/pages/home/OnlineHome.tsx
@@ -41,7 +41,7 @@ const OnlineHome: () => JSX.Element = () => {
   function handleScreenChange(this: MediaQueryList): void {
     // Is the screen size mobile size
     if (this.matches) {
-      // True when the screen-width is at most 52em
+      // True when the screen-width is at most 55em
       setIsMobile(true);
     } else {
       setIsMobile(false);


### PR DESCRIPTION
In Spanish, right before the cutoff to switch to the mobile navbar, the screen glitches and constantly switches between having one-line and two-lines for the navigation. It won't even let me switch to English when the window is this size since it's constantly switching, so the button doesn't exist there long enough for me to click it.

This attempt to fix is resulting in several problems:

- At a certain window size (before mobile), the Spanish menu is still using two-lines
- The three-lines for the mobile menu is showing up in the middle of the page instead of at the far right sometimes
- The front page's dial box is overflowing in Spanish, but it's not switching to the mobile format even when the mobile size on the home page is updated