### PR TITLE
Fix the Manage Sensor scrolling

### DIFF
--- a/src/components/Admin/ManageSensors/SensorTable/ErrorTag.tsx
+++ b/src/components/Admin/ManageSensors/SensorTable/ErrorTag.tsx
@@ -43,24 +43,24 @@ const ErrorTag: ({name, explanation}: ErrorTagProps) => JSX.Element = ({
           {name}
         </Button>
       </PopoverTrigger>
-        <PopoverContent>
-          <PopoverArrow />
-          <PopoverHeader>
-            <Flex alignItems="center" justifyContent="center">
-              <HStack>
-                <WarningTwoIcon color="red.500" />
-                <Heading size="md" textAlign="center">
-                  {name}
-                </Heading>
-                <WarningTwoIcon color="red.500" />
-              </HStack>
-            </Flex>
-          </PopoverHeader>
-          <PopoverCloseButton />
-          <PopoverBody>
-            <Text>{explanation}</Text>
-          </PopoverBody>
-        </PopoverContent>
+      <PopoverContent>
+        <PopoverArrow />
+        <PopoverHeader>
+          <Flex alignItems="center" justifyContent="center">
+            <HStack>
+              <WarningTwoIcon color="red.500" />
+              <Heading size="md" textAlign="center">
+                {name}
+              </Heading>
+              <WarningTwoIcon color="red.500" />
+            </HStack>
+          </Flex>
+        </PopoverHeader>
+        <PopoverCloseButton />
+        <PopoverBody>
+          <Text>{explanation}</Text>
+        </PopoverBody>
+      </PopoverContent>
     </Popover>
   );
 };

--- a/src/components/Admin/ManageSensors/SensorTable/ErrorTag.tsx
+++ b/src/components/Admin/ManageSensors/SensorTable/ErrorTag.tsx
@@ -3,7 +3,6 @@ import {
   Popover,
   PopoverTrigger,
   Button,
-  Portal,
   PopoverArrow,
   PopoverContent,
   PopoverHeader,
@@ -44,7 +43,6 @@ const ErrorTag: ({name, explanation}: ErrorTagProps) => JSX.Element = ({
           {name}
         </Button>
       </PopoverTrigger>
-      <Portal>
         <PopoverContent>
           <PopoverArrow />
           <PopoverHeader>
@@ -63,7 +61,6 @@ const ErrorTag: ({name, explanation}: ErrorTagProps) => JSX.Element = ({
             <Text>{explanation}</Text>
           </PopoverBody>
         </PopoverContent>
-      </Portal>
     </Popover>
   );
 };


### PR DESCRIPTION
Wrapping the error popovers in a `Portal` tag (remnant of copy/paste sample `Popover` code from Chakra) caused the scrolling to stop working.

From the Chakra UI docs:
> Portal is used to transport any component or element to the end of document.body and renders a React tree into it.
> 
> Useful for rendering a natural React element hierarchy with a different DOM hierarchy to prevent parent styles from clipping or hiding content (for popovers, dropdowns, and modals). It supports nested portals

Basically, I think a side effect of the `Portal` tag with the error popovers was that it overrode the `overflow="auto"` setting so that content wouldn't be hidden